### PR TITLE
add screen wake lock to recipe page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@radix-ui/react-select": "^2.1.6",
         "@radix-ui/react-separator": "^1.1.2",
         "@radix-ui/react-slot": "^1.1.2",
+        "@radix-ui/react-switch": "^1.1.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.479.0",
@@ -1221,6 +1222,35 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.1.3.tgz",
+      "integrity": "sha512-1nc+vjEOQkJVsJtWPSiISGT6OKm4SiOdjMo+/icLxo2G4vxz1GntC5MzfL4v8ey9OEfw787QCD1y3mUv0NiFEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "@radix-ui/react-use-previous": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@radix-ui/react-select": "^2.1.6",
     "@radix-ui/react-separator": "^1.1.2",
     "@radix-ui/react-slot": "^1.1.2",
+    "@radix-ui/react-switch": "^1.1.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.479.0",

--- a/src/components/recipe-info/recipe-info.tsx
+++ b/src/components/recipe-info/recipe-info.tsx
@@ -1,5 +1,6 @@
 import { Clock, CookingPot, Goal, Utensils } from 'lucide-react'
 import React from 'react'
+import WakeLockSwitch from '../wake-lock-switch/wake-lock-switch'
 
 export default function RecipeInfo({
   prepTimeMinutes,
@@ -26,6 +27,7 @@ export default function RecipeInfo({
       <p className="flex gap-2">
         <Goal /> {difficulty} level
       </p>
+      <WakeLockSwitch />
     </section>
   )
 }

--- a/src/components/ui/switch.tsx
+++ b/src/components/ui/switch.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as SwitchPrimitive from "@radix-ui/react-switch"
+
+import { cn } from "@/lib/utils"
+
+function Switch({
+  className,
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      className={cn(
+        "peer data-[state=checked]:bg-primary data-[state=unchecked]:bg-input focus-visible:border-ring focus-visible:ring-ring/50 dark:data-[state=unchecked]:bg-input/80 inline-flex h-[1.15rem] w-8 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0"
+        )}
+      />
+    </SwitchPrimitive.Root>
+  )
+}
+
+export { Switch }

--- a/src/components/wake-lock-switch/wake-lock-switch.tsx
+++ b/src/components/wake-lock-switch/wake-lock-switch.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import { Switch } from '../ui/switch'
+const WakeLockSwitch = () => {
+  const [{ isWakeLocked, wakelock }, setWakeLock] = useState<{
+    isWakeLocked: boolean
+    wakelock: WakeLockSentinel | null
+  }>({
+    isWakeLocked: false,
+    wakelock: null
+  })
+  const [disabled, setDisabled] = useState<boolean>(false)
+
+  useEffect(() => {
+    // check if wake lock is supported
+    if ('wakeLock' in navigator === false) {
+      setDisabled(true)
+    }
+  }, [])
+
+  const handleChange = useCallback(
+    async (checked: boolean) => {
+      if (checked) {
+        // enable wakelock
+        const temp = await navigator.wakeLock.request('screen')
+        setWakeLock((prev) => {
+          return {
+            ...prev,
+            isWakeLocked: true,
+            wakelock: temp
+          }
+        })
+      } else {
+        // disable wakelock
+        wakelock?.release()
+        setWakeLock((prev) => {
+          return {
+            ...prev,
+            isWakeLocked: false
+          }
+        })
+      }
+    },
+    [isWakeLocked, wakelock]
+  )
+
+  return (
+    <div className="mt-5 flex items-center">
+      <Switch
+        className="data-[state=checked]:bg-orange-400 data-[state=unchecked]:bg-orange-200 mr-3 data-[state=unchecked]:disabled:bg-gray-300"
+        onCheckedChange={(checked) => handleChange(checked)}
+        disabled={disabled}
+        id="toggle-cook-mode"
+      />
+
+      <label htmlFor="toggle-cook-mode">
+        {disabled ? (
+          <p className="text-sm">Cook mode unavailable on this browser</p>
+        ) : (
+          <p>
+            <strong>Cook mode</strong> (keep screen awake)
+          </p>
+        )}
+      </label>
+    </div>
+  )
+}
+
+export default WakeLockSwitch


### PR DESCRIPTION
This PR adds a wake lock toggle to the recipe page, which keeps the screen from going to sleep when enabled.
Note: This can't currently be tested on mobile (iOS, at least) as it seems that the Screen Wake Lock API only works on localhost and https.